### PR TITLE
enabling to use double underscore delimiters

### DIFF
--- a/Gcp.SecretManager.Provider/SecretManagerConfigurationProvider.cs
+++ b/Gcp.SecretManager.Provider/SecretManagerConfigurationProvider.cs
@@ -31,7 +31,7 @@ namespace Gcp.SecretManager.Provider
                 {
                     var secretVersionName = new SecretVersionName(secret.SecretName.ProjectId, secret.SecretName.SecretId, "latest");
                     var secretVersion = await _client.AccessSecretVersionAsync(secretVersionName);
-                    Set(secret.SecretName.SecretId, secretVersion.Payload.Data.ToStringUtf8());
+                    Set(ConvertDelimiter(secret.SecretName.SecretId), secretVersion.Payload.Data.ToStringUtf8());
                 } catch (Grpc.Core.RpcException)
                 {
                     // This might happen if secret is created but it has no versions available
@@ -39,6 +39,11 @@ namespace Gcp.SecretManager.Provider
                 }
             }
 
+        }
+
+        private static string ConvertDelimiter(string key)
+        {
+            return key.Replace("__", ConfigurationPath.KeyDelimiter);
         }
     }
 }


### PR DESCRIPTION
Thank you for developing a very useful and simple library.

In my project, I needed to use a hierarchical configuration, so I added it.
Using (`__` ) for SecretID, covert to `:`. (It will be interpreted as a delimiter by the configuration provider https://github.com/aspnet/Configuration/blob/master/src/Config.Abstractions/ConfigurationPath.cs#L17)

This implementation is based on the following documentation and source code.
https://docs.microsoft.com/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#environment-variables
https://github.com/aspnet/Configuration/blob/master/src/Config.EnvironmentVariables/EnvironmentVariablesConfigurationProvider.cs#L65-L68

Thank you.